### PR TITLE
chore: update dependencies and require Node 14 for create-react-wptheme

### DIFF
--- a/packages/create-react-wptheme/createReactWpTheme.js
+++ b/packages/create-react-wptheme/createReactWpTheme.js
@@ -37,6 +37,7 @@ const execSync = require("child_process").execSync;
 const spawn = require("cross-spawn");
 const dns = require("dns");
 const url = require("url");
+const envinfo = require("envinfo");
 
 const packageJson = require("./package.json");
 const _wpThemeVersion = packageJson.version;

--- a/packages/create-react-wptheme/package.json
+++ b/packages/create-react-wptheme/package.json
@@ -28,7 +28,7 @@
     "author": "devloco",
     "license": "MIT",
     "engines": {
-        "node": ">=8"
+        "node": ">=14"
     },
     "bugs": {
         "url": "https://github.com/devloco/create-react-wptheme/issues"
@@ -42,13 +42,13 @@
         "create-react-wptheme": "./index.js"
     },
     "dependencies": {
-        "chalk": "3.0.0",
-        "commander": "2.20.0",
-        "cross-spawn": "6.0.5",
-        "envinfo": "7.3.1",
-        "fs-extra": "7.0.1",
-        "semver": "6.3.0",
-        "tmp": "0.0.33",
-        "validate-npm-package-name": "3.0.0"
+        "chalk": "^4.1.2",
+        "commander": "^6.2.1",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.14.0",
+        "fs-extra": "^11.3.1",
+        "semver": "^7.7.2",
+        "tmp": "^0.2.5",
+        "validate-npm-package-name": "^6.0.2"
     }
 }


### PR DESCRIPTION
## Summary
- require Node 14+
- refresh CLI dependencies and add missing envinfo import

## Testing
- `npm install`
- `node index.js --info dummy`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd3a4a34832384b59ea7ac960029