### PR TITLE
chore: update utils deps and websocket server

### DIFF
--- a/packages/create-react-wptheme-utils/fileFunctions.js
+++ b/packages/create-react-wptheme-utils/fileFunctions.js
@@ -12,6 +12,10 @@ const path = require("path");
 const { rm, cp } = require("shelljs");
 const wpThemePostInstallerInfo = require("@devloco/create-react-wptheme-utils/postInstallerInfo");
 const wpThemeUserConfig = require("@devloco/create-react-wptheme-utils/getUserConfig"); //(paths, process.env.NODE_ENV);
+let chalk;
+import("chalk").then((m) => {
+    chalk = m.default;
+});
 
 const _doNotEditFileName = "!DO_NOT_EDIT_THESE_FILES!.txt";
 const _readyToDeployFileName = "!READY_TO_DEPLOY!.txt";
@@ -26,7 +30,7 @@ const _forBuild = () => {
         case "production":
             return true;
         default:
-            console.log(chalk.red(`Unknown env.NODE_ENV: ${nodeEnv}`));
+            console.log(chalk ? chalk.red(`Unknown env.NODE_ENV: ${nodeEnv}`) : `Unknown env.NODE_ENV: ${nodeEnv}`);
             return false;
     }
 };

--- a/packages/create-react-wptheme-utils/getUserConfig.js
+++ b/packages/create-react-wptheme-utils/getUserConfig.js
@@ -8,8 +8,11 @@
 "use strict";
 
 const fs = require("fs-extra");
-const chalk = require("chalk");
 const path = require("path");
+let chalk;
+import("chalk").then((m) => {
+    chalk = m.default;
+});
 const wpThemePostInstallerInfo = require("@devloco/create-react-wptheme-utils/postInstallerInfo");
 
 const _userDevConfigName = "user.dev.json";
@@ -87,7 +90,7 @@ module.exports = function (paths, nodeEnv) {
         case "production":
             return _getUserConfig(paths, _userProdConfigName, defaultUserProdConfig);
         default:
-            console.log(chalk.red(`Unknown env.NODE_ENV: ${nodeEnv}`));
+            console.log(chalk ? chalk.red(`Unknown env.NODE_ENV: ${nodeEnv}`) : `Unknown env.NODE_ENV: ${nodeEnv}`);
             return null;
     }
 };

--- a/packages/create-react-wptheme-utils/package.json
+++ b/packages/create-react-wptheme-utils/package.json
@@ -3,7 +3,7 @@
     "version": "3.4.1-wp.2",
     "description": "Utilities used by create-react-wptheme.",
     "engines": {
-        "node": ">=8"
+        "node": ">=12"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
@@ -28,11 +28,11 @@
         "wpThemeServer.js"
     ],
     "dependencies": {
-        "chalk": "2.4.2",
-        "chokidar": "^3.3.1",
+        "chalk": "^5.3.0",
+        "chokidar": "^3.5.3",
         "shelljs": "^0.8.3",
         "fs-extra": "^8.1.0",
-        "ws": "^7.2.3"
+        "ws": "^8.13.0"
     },
     "devDependencies": {}
 }

--- a/packages/create-react-wptheme-utils/wpThemeServer.js
+++ b/packages/create-react-wptheme-utils/wpThemeServer.js
@@ -11,7 +11,11 @@ const fs = require("fs");
 const path = require("path");
 const url = require("url");
 const https = require("https");
-const WebSocket = require("ws");
+const { WebSocketServer } = require("ws");
+let chalk;
+import("chalk").then((m) => {
+    chalk = m.default;
+});
 
 const _getUserConfig = require("@devloco/create-react-wptheme-utils/getUserConfig");
 const _typeBuildError = "errors";
@@ -141,7 +145,7 @@ function _webSocketServerSetup() {
 }
 
 function _startNonSslServer() {
-    _webSocketServer = new WebSocket.Server({ port: _serverPort });
+    _webSocketServer = new WebSocketServer({ port: _serverPort });
     _webSocketServerSetup();
 }
 
@@ -186,7 +190,7 @@ function _startSslServer() {
         process.exit(1);
     }
 
-    _webSocketServer = new WebSocket.Server({ server: _webServer });
+    _webSocketServer = new WebSocketServer({ server: _webServer });
     _webSocketServerSetup();
 
     _webServer.listen(_serverPort);
@@ -224,10 +228,15 @@ const wpThemeServer = {
                 toInject = [phpStuff, jsTags.join("\n"), jsCall];
                 break;
             default:
-                console.log(chalk.magenta(`wpstart::injectWpThemeClient: unknown inject mode: ${mode}.`));
-                console.log(`Available inject modes: ${chalk.cyan("disable, afterToken, beforeToken, replaceToken, endOfFile")}`);
+                if (chalk) {
+                    console.log(chalk.magenta(`wpstart::injectWpThemeClient: unknown inject mode: ${mode}.`));
+                    console.log(`Available inject modes: ${chalk.cyan("disable, afterToken, beforeToken, replaceToken, endOfFile")}`);
+                } else {
+                    console.log(`wpstart::injectWpThemeClient: unknown inject mode: ${mode}.`);
+                    console.log("Available inject modes: disable, afterToken, beforeToken, replaceToken, endOfFile");
+                }
                 process.exit();
-        }
+            }
 
         _clientInjectString = toInject.join("\n");
 


### PR DESCRIPTION
## Summary
- upgrade create-react-wptheme-utils dependencies to chalk 5, ws 8, and chokidar 3.5
- switch wpThemeServer to `WebSocketServer` and load chalk via dynamic import across utils

## Testing
- `npm test` (fails: Error: no test specified)
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a1dd4e51d88323b68de0481f3290cf