### PR TITLE
Use React 18 createRoot API

### DIFF
--- a/packages/cra-template-wptheme-typescript/template/src/index.tsx
+++ b/packages/cra-template-wptheme-typescript/template/src/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/packages/cra-template-wptheme/template/src/index.js
+++ b/packages/cra-template-wptheme/template/src/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
## Summary
- use `createRoot`/`root.render` in JavaScript template
- apply same update for TypeScript template

## Testing
- `npm list react react-dom` (in generated sample)
- `npm test -- --watchAll=false` (fails: TypeError: _reactDom.default.render is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68a1dd52b8c083239153e661f37a0466