### PR TITLE
chore: update deps and require node 14

### DIFF
--- a/packages/create-react-wptheme/createReactWpTheme.js
+++ b/packages/create-react-wptheme/createReactWpTheme.js
@@ -37,6 +37,7 @@ const execSync = require("child_process").execSync;
 const spawn = require("cross-spawn");
 const dns = require("dns");
 const url = require("url");
+const envinfo = require("envinfo");
 
 const packageJson = require("./package.json");
 const _wpThemeVersion = packageJson.version;
@@ -93,7 +94,7 @@ const scriptsFromGit = function () {
 let projectName;
 const program = new commander.Command(packageJson.name)
     .version(packageJson.version)
-    .arguments("<project-directory>")
+    .argument("[project-directory]")
     .usage(`${chalk.green("<project-directory>")} [options]`)
     .action((name) => {
         projectName = name;
@@ -113,7 +114,9 @@ const program = new commander.Command(packageJson.name)
     })
     .parse(process.argv);
 
-if (program.info) {
+const options = program.opts();
+
+if (options.info) {
     console.log(chalk.bold("\nEnvironment Info:"));
     return envinfo
         .run(
@@ -154,7 +157,7 @@ function printValidationResults(results) {
 console.log(program.name() + " version: " + chalk.magenta(_wpThemeVersion));
 console.log("@devloco/react-scripts-wptheme version: " + chalk.magenta(_reactScriptsWpThemeVersion));
 console.log();
-createApp(projectName, program.verbose, program.scriptsVersion, program.useNpm, program.usePnp, program.typescript);
+createApp(projectName, options.verbose, options.scriptsVersion, options.useNpm, options.usePnp, options.typescript);
 
 function createApp(name, verbose, version, useNpm, usePnp, useTypescript, template) {
     const root = path.resolve(name);

--- a/packages/create-react-wptheme/index.js
+++ b/packages/create-react-wptheme/index.js
@@ -32,9 +32,9 @@ var currentNodeVersion = process.versions.node;
 var semver = currentNodeVersion.split(".");
 var major = semver[0];
 
-if (major < 8) {
+if (major < 14) {
     console.error(chalk.red(`You are running Node ${currentNodeVersion}.`));
-    console.error(chalk.red("Create React WP Theme requires Node 8 or higher."));
+    console.error(chalk.red("Create React WP Theme requires Node 14 or higher."));
     console.error(chalk.red("Please update your version of Node."));
     process.exit(1);
 }

--- a/packages/create-react-wptheme/package.json
+++ b/packages/create-react-wptheme/package.json
@@ -28,7 +28,7 @@
     "author": "devloco",
     "license": "MIT",
     "engines": {
-        "node": ">=8"
+        "node": ">=14"
     },
     "bugs": {
         "url": "https://github.com/devloco/create-react-wptheme/issues"
@@ -42,13 +42,13 @@
         "create-react-wptheme": "./index.js"
     },
     "dependencies": {
-        "chalk": "3.0.0",
-        "commander": "2.20.0",
-        "cross-spawn": "6.0.5",
-        "envinfo": "7.3.1",
-        "fs-extra": "7.0.1",
-        "semver": "6.3.0",
-        "tmp": "0.0.33",
-        "validate-npm-package-name": "3.0.0"
+        "chalk": "4.1.2",
+        "commander": "14.0.0",
+        "cross-spawn": "7.0.6",
+        "envinfo": "7.14.0",
+        "fs-extra": "11.3.1",
+        "semver": "7.7.2",
+        "tmp": "0.2.5",
+        "validate-npm-package-name": "6.0.2"
     }
 }


### PR DESCRIPTION
## Summary
- require Node 14+ and upgrade CLI dependencies
- adapt CLI to commander v14 and load envinfo
- ensure Node version check matches new minimum

## Testing
- `node index.js --info`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a328d963e48323b5e9206ed0d3ee38