### PR TITLE
chore: update Node requirement

### DIFF
--- a/packages/create-react-wptheme/createReactWpTheme.js
+++ b/packages/create-react-wptheme/createReactWpTheme.js
@@ -20,7 +20,7 @@
 // tell people to update their global version of create-react-wptheme.
 //
 // Also be careful with new language features.
-// This file must work on Node 6+.
+// This file must work on Node 14+.
 //
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //   /!\ DO NOT MODIFY THIS FILE /!\


### PR DESCRIPTION
## Summary
- require Node 14+ in createReactWpTheme.js comment

## Testing
- `npm test` (fails: Missing script: "test")
- `cd packages/create-react-wptheme && npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a337edf3248323a977ad144a3a9fdc