### PR TITLE
chore: use latest commander

### DIFF
--- a/packages/create-react-wptheme/package.json
+++ b/packages/create-react-wptheme/package.json
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "chalk": "4.1.2",
-        "commander": "14.0.0",
+        "commander": "^14.0.0",
         "cross-spawn": "7.0.6",
         "envinfo": "7.14.0",
         "fs-extra": "11.3.1",


### PR DESCRIPTION
## Summary
- loosen commander dependency to ^14.0.0 for create-react-wptheme package

## Testing
- `npm install`
- `node index.js --help`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a337ef3fa4832393d54aa8513fef06