### PR TITLE
fix: align engines and dependencies

### DIFF
--- a/packages/cra-template-wptheme-typescript/package.json
+++ b/packages/cra-template-wptheme-typescript/package.json
@@ -17,7 +17,7 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=8.10"
+        "node": ">=14"
     },
     "bugs": {
         "url": "https://github.com/devloco/create-react-wptheme/issues"

--- a/packages/cra-template-wptheme/package.json
+++ b/packages/cra-template-wptheme/package.json
@@ -25,7 +25,7 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=8"
+        "node": ">=14"
     },
     "bugs": {
         "url": "https://github.com/devloco/create-react-wptheme/issues"

--- a/packages/create-react-wptheme-utils/package.json
+++ b/packages/create-react-wptheme-utils/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
-        "shelljs": "^0.10.0",
+        "shelljs": "0.8.5",
         "fs-extra": "^11.3.1",
         "ws": "^8.18.3"
     },

--- a/packages/create-react-wptheme/package.json
+++ b/packages/create-react-wptheme/package.json
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "chalk": "4.1.2",
-        "commander": "^14.0.0",
+        "commander": "^9.5.0",
         "cross-spawn": "7.0.6",
         "envinfo": "7.14.0",
         "fs-extra": "11.3.1",


### PR DESCRIPTION
## Summary
- downgrade commander to v9 for Node 14 support
- use shelljs 0.8.5 and standardize engine constraints to Node 14+
- require Node 14+ in templates

## Testing
- `npm install --no-package-lock` in `packages/create-react-wptheme`
- `npm install --no-package-lock` in `packages/create-react-wptheme-utils`
- `npm install --no-package-lock` in `packages/cra-template-wptheme`
- `npm install --no-package-lock` in `packages/cra-template-wptheme-typescript`
- `node packages/create-react-wptheme/index.js --help`


------
https://chatgpt.com/codex/tasks/task_e_68a3421762748323b59f156f0f508ff8