### PR TITLE
chore: update TS and Node types in template

### DIFF
--- a/packages/cra-template-wptheme-typescript/template.json
+++ b/packages/cra-template-wptheme-typescript/template.json
@@ -5,10 +5,10 @@
       "@testing-library/react": "^13.4.0",
       "@testing-library/user-event": "^13.5.0",
       "@types/jest": "^27.5.2",
-      "@types/node": "^16.18.11",
+      "@types/node": "^20",
       "@types/react": "^18.0.27",
       "@types/react-dom": "^18.0.10",
-      "typescript": "^4.9.5",
+      "typescript": "^5.5.3",
       "web-vitals": "^2.1.4"
     }
   }


### PR DESCRIPTION
## Summary
- bump `typescript` in TypeScript template to ^5.5.3
- target Node 20 types with `@types/node`

## Testing
- `npx create-react-app@latest sample-theme --use-npm --template file:/workspace/create-react-wptheme/packages/cra-template-wptheme-typescript`
- `npm run build` *(fails: Can't resolve './reportWebVitals')*
- `npm test -- --passWithNoTests` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a342170d5c8323b8991c57f7ce2929