### PR TITLE
refactor: centralize validation dependencies

### DIFF
--- a/packages/create-react-wptheme/createReactWpTheme.js
+++ b/packages/create-react-wptheme/createReactWpTheme.js
@@ -38,6 +38,7 @@ const spawn = require("cross-spawn");
 const dns = require("dns");
 const url = require("url");
 const envinfo = require("envinfo");
+const validationDeps = require("./validationDeps");
 
 const packageJson = require("./package.json");
 const _wpThemeVersion = packageJson.version;
@@ -277,8 +278,8 @@ function checkAppName(appName) {
         process.exit(1);
     }
 
-    // TODO: there should be a single place that holds the dependencies
-    const dependencies = ["react", "react-dom", "react-scripts", "@devloco/react-scripts-wptheme"].sort();
+    // Dependency names that cannot be used as project names are stored in validationDeps.js
+    const dependencies = validationDeps.slice().sort();
     if (dependencies.indexOf(appName) >= 0) {
         console.error(
             chalk.red(`We cannot create a project called ${chalk.green(appName)} because a dependency with the same name exists.\n` + `Due to the way npm works, the following names are not allowed:\n\n`) +

--- a/packages/create-react-wptheme/package.json
+++ b/packages/create-react-wptheme/package.json
@@ -35,7 +35,8 @@
     },
     "files": [
         "index.js",
-        "createReactWpTheme.js"
+        "createReactWpTheme.js",
+        "validationDeps.js"
     ],
     "homepage": "https://github.com/devloco/create-react-wptheme",
     "bin": {

--- a/packages/create-react-wptheme/validationDeps.js
+++ b/packages/create-react-wptheme/validationDeps.js
@@ -1,0 +1,8 @@
+const validationDeps = Object.freeze([
+  "react",
+  "react-dom",
+  "react-scripts",
+  "@devloco/react-scripts-wptheme",
+]);
+
+module.exports = validationDeps;


### PR DESCRIPTION
## Summary
- extract dependency list for app name validation into reusable module
- reference new validationDeps in createReactWpTheme
- include validationDeps.js in package files
- freeze validation dependency list to prevent accidental mutation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a342171c2c8323a6ccd916d804ab98